### PR TITLE
Robustness

### DIFF
--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -283,7 +283,7 @@ expected_sysex_length(const unsigned char status, const unsigned char *second_by
 {
 	int sysex_length, len;
 
-	assert(status == 0xF0);
+	assert(status == 0xF0 || status == 0xF7);
 
 	if (buffer_length < 3) {
 		g_critical("SMF error: end of buffer in expected_sysex_length().");
@@ -441,7 +441,7 @@ extract_escaped_event(const unsigned char *buf, const int buffer_length, smf_eve
 
 	message_length = expected_escaped_length(status, c, buffer_length - 1, &vlq_length);
 
-	if (message_length < 0)
+	if (message_length <= 0)
 		return (-3);
 
 	c += vlq_length;

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -460,12 +460,12 @@ extract_escaped_event(const unsigned char *buf, const int buffer_length, smf_eve
 
 	memcpy(event->midi_buffer, c, message_length);
 
-	if (smf_event_is_valid(event)) {
+	if (!smf_event_is_valid(event)) {
 		g_critical("Escaped event is invalid.");
 		return (-1);
 	}
 
-	if (smf_event_is_system_realtime(event) || smf_event_is_system_common(event)) {
+	if (!(smf_event_is_system_realtime(event) || smf_event_is_system_common(event))) {
 		g_warning("Escaped event is not System Realtime nor System Common.");
 	}
 

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -780,6 +780,11 @@ parse_mtrk_chunk(smf_track_t *track)
 	}
 
 	for (;;) {
+		if (track->next_event_offset == track->file_buffer_length) {
+			g_warning("SMF warning: The track did not finish with the End of Track event.");
+			break;
+		}
+
 		event = parse_next_event(track);
 
 		/* Couldn't parse an event? */

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -889,6 +889,7 @@ smf_load_from_memory(const void *buffer, const int buffer_length)
 		if (parse_mtrk_chunk(track)) {
 			g_warning("SMF warning: Cannot load track.");
 			smf_track_delete(track);
+			break;
 		}
 
 		track->file_buffer = NULL;

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -768,10 +768,16 @@ smf_event_is_valid(const smf_event_t *event)
 static int
 parse_mtrk_chunk(smf_track_t *track)
 {
+	smf_t *smf = track->smf;
 	smf_event_t *event;
 
 	if (parse_mtrk_header(track))
 		return (-1);
+
+	if (track->file_buffer + track->file_buffer_length > smf->file_buffer + smf->file_buffer_length) {
+		/* Truncated track? */
+		track->file_buffer_length = smf->file_buffer_length - (track->file_buffer - smf->file_buffer);
+	}
 
 	for (;;) {
 		event = parse_next_event(track);

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -890,13 +890,17 @@ smf_load_from_memory(const void *buffer, const int buffer_length)
 	smf->file_buffer_length = buffer_length;
 	smf->next_chunk_offset = 0;
 
-	if (parse_mthd_chunk(smf))
+	if (parse_mthd_chunk(smf)) {
+		smf_delete(smf);
 		return (NULL);
+        }
 
 	for (i = 1; i <= smf->expected_number_of_tracks; i++) {
 		smf_track_t *track = smf_track_new();
-		if (track == NULL)
+		if (track == NULL) {
+			smf_delete(smf);
 			return (NULL);
+		}
 
 		smf_add_track(smf, track);
 

--- a/src/smf_load.c
+++ b/src/smf_load.c
@@ -503,11 +503,21 @@ extract_midi_event(const unsigned char *buf, const int buffer_length, smf_event_
 		return (-1);
 	}
 
-	if (is_sysex_byte(status))
+	if (is_sysex_byte(status)) {
+		if (c == buf) {
+			g_critical("SMF error: running status is not applicable to System Exclusive events.");
+			return (-2);
+		}
 		return (extract_sysex_event(buf, buffer_length, event, len, last_status));
+	}
 
-	if (is_escape_byte(status))
+	if (is_escape_byte(status)) {
+		if (c == buf) {
+			g_critical("SMF error: running status is not applicable to Escape events.");
+			return (-2);
+		}
 		return (extract_escaped_event(buf, buffer_length, event, len, last_status));
+	}
 
 	/* At this point, "c" points to first byte following the status byte. */
 	message_length = expected_message_length(status, c, buffer_length - (c - buf));

--- a/src/smf_tempo.c
+++ b/src/smf_tempo.c
@@ -133,6 +133,11 @@ maybe_add_to_tempo_map(smf_event_t *event)
 
 	/* Tempo Change? */
 	if (event->midi_buffer[1] == 0x51) {
+		if (event->midi_buffer_length < 6) {
+			g_critical("Tempo Change event seems truncated.");
+			return;
+		}
+
 		int new_tempo = (event->midi_buffer[3] << 16) + (event->midi_buffer[4] << 8) + event->midi_buffer[5];
 		if (new_tempo <= 0) {
 			g_critical("Ignoring invalid tempo change.");


### PR DESCRIPTION
- fix a buffer overflow in tempo change parsing. test case [16-elo_1977-birmingham_blues-[k].mid.gz](https://github.com/stump/libsmf/files/2801658/16-elo_1977-birmingham_blues-.k.mid.gz)
- fix an assertion raised in the sysex size routine, also used by escape events (F7). fixed also a size check in escape events, which can allow the input to create an invalid size 0 event; unlike sysex, this one does not have an implied status byte. [01-pink_floyd_1975-shine_on_you_crazy_diamond_(part_1).mid.gz](https://github.com/stump/libsmf/files/2801725/01-pink_floyd_1975-shine_on_you_crazy_diamond_.part_1.mid.gz)
- fix the case of truncated files, where the track length will extend beyond the file buffer without a check, resulting in a buffer overflow. test case [try_get_along.mid.gz](https://github.com/stump/libsmf/files/2801841/try_get_along.mid.gz)
- fix heap use after free, by stopping after the first track which fails parsing. same file as above
- in a case when the track does not end with the EOT meta-event, the library can attempt to parse an event from a 0-length buffer, and raise an assertion. [04-mark_knopfler_&_chet_atkins_1990-just_on_time-[demo].mid.gz](https://github.com/stump/libsmf/files/2801932/04-mark_knopfler_._chet_atkins_1990-just_on_time-.demo.mid.gz)
- fix the assertion `is_sysex_byte(status)` which raises when the sysex or escape event tries to use running status. this is non-standard and libsmf does not support it, so I enforced the check, however some files will use it anyway. test case [tmm_Kag_Theme.mid.gz](https://github.com/stump/libsmf/files/2802224/tmm_Kag_Theme.mid.gz)
- fix the logic error which will let escape events through only if they are invalid.. although it's logical, this may degrade compatibility with non-standard files. if libsmf must support wider cases of escape events, it should implement proper support. test case [Main_Lobby.mid.gz](https://github.com/stump/libsmf/files/2802318/Main_Lobby.mid.gz)
- fix a memory leak in case of failure in `smf_load_from_memory`